### PR TITLE
Ed25519 seed keypair

### DIFF
--- a/c_src/enacl_nif.c
+++ b/c_src/enacl_nif.c
@@ -204,7 +204,7 @@ ERL_NIF_TERM enif_crypto_sign_ed25519_public_to_curve25519(ErlNifEnv *env, int a
 
 	if ((argc != 1)
 			|| (!enif_inspect_binary(env, argv[0], &ed25519_pk))
-			|| (ed25519_pk.size != crypto_sign_ed25519_SEEDBYTES)) {
+			|| (ed25519_pk.size != crypto_sign_ed25519_PUBLICKEYBYTES)) {
 		return enif_make_badarg(env);
 	}
 

--- a/src/enacl.erl
+++ b/src/enacl.erl
@@ -82,6 +82,7 @@
 %% Ed 25519.
 -export([
          crypto_sign_ed25519_keypair/0,
+         crypto_sign_ed25519_seed_keypair/1,
          crypto_sign_ed25519_public_to_curve25519/1,
          crypto_sign_ed25519_secret_to_curve25519/1,
          crypto_sign_ed25519_public_size/0,
@@ -908,6 +909,14 @@ curve25519_scalarmult(#{ secret := Secret, base_point := BasePoint }) ->
 -spec crypto_sign_ed25519_keypair() -> #{ atom() => binary() }.
 crypto_sign_ed25519_keypair() ->
     {PK, SK} = enacl_nif:crypto_sign_ed25519_keypair(),
+    #{ public => PK, secret => SK }.
+
+%% Generates and returns a seeded key pair for the Ed 25519 signature scheme. The return value is a
+%% map in order to avoid using the public key as a secret key and vice versa.
+%% @end
+-spec crypto_sign_ed25519_seed_keypair(Seed :: binary()) -> #{ atom() => binary() }.
+crypto_sign_ed25519_seed_keypair(Seed) ->
+    {PK, SK} = enacl_nif:crypto_sign_ed25519_seed_keypair(Seed),
     #{ public => PK, secret => SK }.
 
 %% @doc crypto_sign_ed25519_public_to_curve25519/1 converts a given Ed 25519 public

--- a/src/enacl_nif.erl
+++ b/src/enacl_nif.erl
@@ -97,10 +97,12 @@
 %% Ed 25519
 -export([
          crypto_sign_ed25519_keypair/0,
+         crypto_sign_ed25519_seed_keypair/1,
          crypto_sign_ed25519_public_to_curve25519/1,
          crypto_sign_ed25519_secret_to_curve25519/1,
          crypto_sign_ed25519_PUBLICKEYBYTES/0,
-         crypto_sign_ed25519_SECRETKEYBYTES/0
+         crypto_sign_ed25519_SECRETKEYBYTES/0,
+         crypto_sign_ed25519_SEEDBYTES/0
         ]).
 
 %% Key exchange
@@ -261,10 +263,12 @@ crypto_onetimeauth_verify_b(_Authenticator, _Msg, _Key) -> erlang:nif_error(nif_
 crypto_curve25519_scalarmult(_Secret, _BasePoint) -> erlang:nif_error(nif_not_loaded).
 
 crypto_sign_ed25519_keypair() -> erlang:nif_error(nif_not_loaded).
+crypto_sign_ed25519_seed_keypair(_Seed) -> erlang:nif_error(nif_not_loaded).
 crypto_sign_ed25519_public_to_curve25519(_PublicKey) -> erlang:nif_error(nif_not_loaded).
 crypto_sign_ed25519_secret_to_curve25519(_SecretKey) -> erlang:nif_error(nif_not_loaded).
 crypto_sign_ed25519_PUBLICKEYBYTES() -> erlang:nif_error(nif_not_loaded).
 crypto_sign_ed25519_SECRETKEYBYTES() -> erlang:nif_error(nif_not_loaded).
+crypto_sign_ed25519_SEEDBYTES() -> erlang:nif_error(nif_not_loaded).
 
 crypto_hash(Input) when is_binary(Input) -> erlang:nif_error(nif_not_loaded).
 crypto_hash_b(Input) when is_binary(Input) -> erlang:nif_error(nif_not_loaded).


### PR DESCRIPTION
Addition of the crypto_sign_ed25519_seed_keypair function. Required when a deterministic key pair is required.